### PR TITLE
Vagrant: ignore deploy config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 config/oauth.php
 log/*
+/.deploy_configuration*


### PR DESCRIPTION
I hope this is not used somewhere for things it shouldn't be used